### PR TITLE
WIP: Implement support for IPv6 networking

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,6 +30,11 @@ adguard_home_container_image_force_pull: "{{ adguard_home_container_image.endswi
 # The base container network. It will be auto-created by this role if it doesn't exist already.
 adguard_home_container_network: "{{ adguard_home_identifier }}"
 
+# Whether to enable IPv6 on the container network.
+adguard_home_container_network_ipv6_enabled: false
+# If IPv6 is enabled, define what subnet should be used inside the network.
+adguard_home_container_network_ipv6_subnet: ""
+
 # A list of additional container networks that the container would be connected to.
 # The role does not create these networks, so make sure they already exist.
 # Use this to expose this container to another reverse proxy, which runs in a different container network.
@@ -44,6 +49,19 @@ adguard_home_container_dns_tcp_bind_port: '53'
 #
 # Takes an "<ip>:<port>" value (e.g. "127.0.0.1:53"), just a port number or an empty string to not expose.
 adguard_home_container_dns_udp_bind_port: "{{ adguard_home_container_dns_tcp_bind_port }}"
+
+# Specified if the container should bind to IPv6 TCP/UDP addresses as
+# well.
+#
+# If you specify adguard_home_container_dns_{tcp,udp}_bind_port as
+# only a port number, then you don't need to change these variables.
+# However, if you define a specific "<IPv4>:<port>" combination on
+# adguard_home_container_dns_tcp_bind_port, then you might want to
+# also set these variables to listen on "<IPv6>:<port>".
+#
+# When specifying an IPv6, please use the "[IP]:PORT" notation.
+adguard_home_container_dns_tcp6_bind_address: ''
+adguard_home_container_dns_udp6_bind_address: ''
 
 # adguard_home_container_labels_traefik_enabled controls whether labels to assist a Traefik reverse-proxy will be attached to the container.
 # See `../templates/labels.j2` for details.

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -38,6 +38,9 @@
   community.general.docker_network:
     name: "{{ adguard_home_container_network }}"
     driver: bridge
+    enable_ipv6: "{{ 'yes' if adguard_home_container_network_ipv6_enabled else 'no' }}"
+    ipam_config:
+      - subnet: "{{ adguard_home_container_network_ipv6_subnet if adguard_home_container_network_ipv6_enabled else omit }}"
 
 - name: Ensure AdGuard Home systemd service is present
   ansible.builtin.template:

--- a/tasks/validate_config.yml
+++ b/tasks/validate_config.yml
@@ -32,3 +32,12 @@
         msg: >-
           adguard_home_container_labels_traefik_path_prefix (`{{ adguard_home_container_labels_traefik_path_prefix }}`) must either be `/` or not end with a slash (e.g. `/adguard-home`).
       when: "adguard_home_container_labels_traefik_path_prefix != '/' and adguard_home_container_labels_traefik_path_prefix[-1] == '/'"
+
+- when: adguard_home_container_network_ipv6_enabled | bool
+  block:
+    - name: Fail if IPv6 is enabled but not subnet is provided
+      ansible.builtin.fail:
+        msg: >-
+          You need to specify an IPv6 subnet when IPv6 is enabled (adguard_home_container_network_ipv6_subnet).
+      when: "adguard_home_container_network_ipv6_subnet == ''"
+

--- a/templates/systemd/adguard-home.service.j2
+++ b/templates/systemd/adguard-home.service.j2
@@ -30,6 +30,12 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% if adguard_home_container_dns_udp_bind_port %}
 			-p {{ adguard_home_container_dns_udp_bind_port }}:53/udp \
 			{% endif %}
+			{% if adguard_home_container_dns_tcp6_bind_address %}
+			-p {{ adguard_home_container_dns_tcp6_bind_address }}:53/tcp \
+			{% endif %}
+			{% if adguard_home_container_dns_udp6_bind_address %}
+			-p {{ adguard_home_container_dns_udp6_bind_address }}:53/udp \
+			{% endif %}
 			--env-file={{ adguard_home_base_path }}/env \
 			--label-file={{ adguard_home_base_path }}/labels \
 			--mount type=bind,src={{ adguard_home_config_path }},dst=/opt/adguardhome/conf \


### PR DESCRIPTION
This commit implements support for IPv6 networking.  The user will be
able to use IPv6 inside the container, and also to bind the container
to an external host's IPv6 address/port.